### PR TITLE
Fix NaN crash in estimate_variance_w_args for highly dominant clusters

### DIFF
--- a/R/main_functions.R
+++ b/R/main_functions.R
@@ -127,10 +127,12 @@ estimate_variance_w_args <- function(pars, counts, total_cells, optim_clusters, 
   }
   pars <- pars / exp(mean(log(pars)))
   for (s in 1:ncol(counts)) {
-    if (sum(pars[s] * total_cells[s] - counts[, s] < 0) > 0) {
+    denom <- pars[s] * total_cells[s] - counts[, s]
+    if (any(denom <= 0)) {
       warning("non-feasible solution for sample ", s)
+      return(.Machine$double.xmax)
     }
-    log_odds[, s] <- log((counts[, s] + 1) / (pars[s] * total_cells[s] - counts[, s]))
+    log_odds[, s] <- log((counts[, s] + 1) / denom)
   }
   for (c in optim_clusters) {
     temp_var_estimate <- (1 / (nsamp - 1)) * t(log_odds[c, ]) %*% centering_matrix %*% ((log_odds[c, ]))


### PR DESCRIPTION
Bug fix for issue #10. 

## Bug

**`estimate_variance_w_args()` crashes when one cluster dominates a sample**
When a cluster holds a very high fraction of a sample's cells (>80%), the log-odds denominator can go negative during optimization, producing `NaN`. `solnp` has an internal `NaN` catch but the crash still propagates downstream into `solnp`'s convergence check.

## Fix 
Return a large finite penalty (`.Machine$double.xmax`) when the denominator is ≤ 0, stopping `NaN` at the source and steering the optimizer away from the infeasible region. This is consistent with how `solnp`'s own internal `NaN` catch works.

## Testing
- Confirmed fix resolves the reprex from #10 
- Results on vignette simulated data are unchanged (estimates differ by <0.3%, signs, significance and biological conclusions identical across all clusters)

Closes #10